### PR TITLE
Update AGENTS with explicit branch step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+Instructions
+-----------
+- Include the following HTML preview link in every pull request description **after** the branch has been created:
+  https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/<branch>/index.html
+  Replace `<branch>` with the actual branch name Codex generates for the PR.
+  Wait until that name is available so the link contains the correct branch instead of a blank placeholder.


### PR DESCRIPTION
## Summary
- clarify that PR link should be added only after the branch name is known

## Testing
- `git status --short`
