### PR TITLE
Update docs for PR preview links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 Instructions
 -----------
-- Include the following HTML preview link in every pull request description **after** the branch has been created:
+Every pull request description **must** include the HTML preview link *after* Codex creates the branch:
   https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/<branch>/index.html
-  Replace `<branch>` with the actual branch name Codex generates for the PR.
-  Wait until that name is available so the link contains the correct branch instead of a blank placeholder.
+Replace `<branch>` with the exact PR branch name, waiting until that name is known so the link is correct and never a placeholder.
+
+Example for a branch named `add-ties-and-slurs-back-kvbg0h`:
+  https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/add-ties-and-slurs-back-kvbg0h/index.html

--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ https://htmlpreview.github.io/?https://raw.githubusercontent.com/<USER>/<REPO>/<
 Replace `<USER>`, `<REPO>` and `<BRANCH>` with the appropriate values to get a
 clickable link for testing a pull request.
 
+All pull request descriptions will include this link automatically with the
+correct branch name, making it easy to preview changes directly from the PR.
+


### PR DESCRIPTION
## Summary
- clarify that PR descriptions must include the HTML preview link with the exact branch name
- document that PRs automatically contain the preview link

https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html