### PR TITLE
Fix tie rendering after file load

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,6 +533,7 @@ document.getElementById('useDefaultFile').addEventListener('click', function() {
       const parser = new DOMParser();
       const xmlDoc = parser.parseFromString(data,"text/xml");
       populateStaffFromMusicXML(xmlDoc);
+      requestAnimationFrame(tieify);
     })
     .catch(error => console.error('Error loading the default file:', error));
 });
@@ -812,7 +813,8 @@ function populateStaffFromMusicXML(xmlDoc) {
     sheet.appendChild(measureDiv);
   }
   beamify();
-  tieify();
+  // Ensure layout is calculated before drawing ties
+  requestAnimationFrame(tieify);
 }
 
 
@@ -862,6 +864,7 @@ function fileHandler(event) {
     const xmlDoc = parser
       .parseFromString(reader.result,"text/xml");
     populateStaffFromMusicXML(xmlDoc);
+    requestAnimationFrame(tieify);
   }
   console.log(event.target.files[0])
   reader.readAsText(event.target.files[0]);


### PR DESCRIPTION
## Summary
- ensure ties are positioned after the layout finishes when loading files

https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html