### PR TITLE
Fix beam rendering after default file load

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,7 +538,10 @@ document.getElementById('useDefaultFile').addEventListener('click', function() {
       const parser = new DOMParser();
       const xmlDoc = parser.parseFromString(data,"text/xml");
       populateStaffFromMusicXML(xmlDoc);
-      requestAnimationFrame(tieify);
+      requestAnimationFrame(() => {
+        beamify();
+        tieify();
+      });
     })
     .catch(error => console.error('Error loading the default file:', error));
 });
@@ -817,9 +820,11 @@ function populateStaffFromMusicXML(xmlDoc) {
 
     sheet.appendChild(measureDiv);
   }
-  beamify();
-  // Ensure layout is calculated before drawing ties
-  requestAnimationFrame(tieify);
+  // Ensure layout is calculated before drawing beams and ties
+  requestAnimationFrame(() => {
+    beamify();
+    tieify();
+  });
 }
 
 


### PR DESCRIPTION
## Summary
- trigger beam and tie redraw when loading default MusicXML file

https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html

## Testing
- `node -v`
