### PR TITLE
Auto render beams on default file load

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,15 +539,16 @@ document.getElementById('renderBeams').addEventListener('click', () => {
   });
 });
 
-document.getElementById('useDefaultFile').addEventListener('click', function() {
-  fetch('ddd.xml') // Adjust the path if your XML file is in a specific directory
-    .then(response => response.text())
-    .then(data => {
-      const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(data,"text/xml");
-      populateStaffFromMusicXML(xmlDoc);
-    })
-    .catch(error => console.error('Error loading the default file:', error));
+document.getElementById('useDefaultFile').addEventListener('click', async function() {
+  try {
+    const response = await fetch('ddd.xml');
+    const data = await response.text();
+    const parser = new DOMParser();
+    const xmlDoc = parser.parseFromString(data,"text/xml");
+    await populateStaffFromMusicXML(xmlDoc);
+  } catch (error) {
+    console.error('Error loading the default file:', error);
+  }
 });
 
  
@@ -807,8 +808,9 @@ function appendMeasureNotes(measure, measureDiv) {
 }
 
 function populateStaffFromMusicXML(xmlDoc) {
-  const parts = xmlDoc.getElementsByTagName("part");
-  const sheet = document.querySelector('.sheet');
+  return new Promise(resolve => {
+    const parts = xmlDoc.getElementsByTagName("part");
+    const sheet = document.querySelector('.sheet');
 
   const measuresByPart = Array.from(parts).map(p => p.getElementsByTagName("measure"));
   const maxMeasures = Math.max(...measuresByPart.map(m => m.length));
@@ -828,6 +830,8 @@ function populateStaffFromMusicXML(xmlDoc) {
   requestAnimationFrame(() => {
     beamify();
     tieify();
+    resolve();
+  });
   });
 }
 
@@ -873,12 +877,11 @@ function plotStaffBlock(existingStaffBlock, pitchSpace, noteType) {
 
 function fileHandler(event) {
   const reader = new FileReader();
-  reader.onload = () => {
+  reader.onload = async () => {
     const parser = new DOMParser();
     const xmlDoc = parser
       .parseFromString(reader.result,"text/xml");
-    populateStaffFromMusicXML(xmlDoc);
-    requestAnimationFrame(tieify);
+    await populateStaffFromMusicXML(xmlDoc);
   }
   console.log(event.target.files[0])
   reader.readAsText(event.target.files[0]);


### PR DESCRIPTION
## Summary
- automatically call `beamify()` when loading the default file
- ensure beams and ties render last using an async `populateStaffFromMusicXML`

HTML Preview: https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html

## Testing
- `git status --short`
