### PR TITLE
Improve melody phrase detection debug controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,6 +382,10 @@ svg {
   left: 0;
 }
 
+.note.phrase-highlight {
+  outline: 2px solid red;
+}
+
 /* .tie-under {
     border-color: green blue red yellow;
     border-radius: 50px 50px 50px 50px;
@@ -413,6 +417,8 @@ svg {
   <button id="renderBeams" title="Render Beams"><i class="fa-solid fa-bars-staggered"></i></button>
   <button id="openSettings" title="Settings"><i class="fa-solid fa-gear"></i></button>
   <button id="toggleDarkMode" title="Toggle dark mode"><i class="fa-solid fa-moon"></i></button>
+  <select id="phraseSelect" title="Detected Melodies"></select>
+  <button id="runDetect" title="Run Detect Again"><i class="fa-solid fa-rotate"></i></button>
 </div>
 
 <div class="sheet" id="zoomContainer"></div>
@@ -501,6 +507,11 @@ svg {
 // Global vars to cache event state
 let evCache = [];
 let prevDiff = -1;
+
+// Global arrays for melody pattern detection
+let noteSteps = [];
+let noteElements = [];
+let detectedPatterns = {};
 
 function init() {
 // Install event handlers for the pointer target
@@ -947,6 +958,12 @@ function appendInterleavedNotes(notesByPart, measureDiv) {
         noteDiv.classList.add(`stem-${n.stem}`);
       }
 
+      if (noteDiv) {
+        noteDiv.dataset.index = noteSteps.length;
+        noteSteps.push(n.step);
+        noteElements.push(noteDiv);
+      }
+
       if (n.ties && n.ties.length) {
         n.ties.forEach(tie => {
           noteDiv.dataset[`tie${tie.number}`] = tie.type;
@@ -996,8 +1013,13 @@ function appendInterleavedNotes(notesByPart, measureDiv) {
 }
 
 function populateStaffFromMusicXML(xmlDoc) {
+  noteSteps = [];
+  noteElements = [];
+  detectedPatterns = {};
+
   const parts = xmlDoc.getElementsByTagName("part");
   const sheet = document.querySelector('.sheet');
+  sheet.innerHTML = '';
 
   const measuresByPart = Array.from(parts).map(p => p.getElementsByTagName("measure"));
   const maxMeasures = Math.max(...measuresByPart.map(m => m.length));
@@ -1016,6 +1038,7 @@ function populateStaffFromMusicXML(xmlDoc) {
   requestAnimationFrame(() => {
     beamify();
     tieify();
+    detectPatternsFromSteps();
   });
 }
 
@@ -1066,7 +1089,6 @@ function fileHandler(event) {
     const xmlDoc = parser
       .parseFromString(reader.result,"text/xml");
     populateStaffFromMusicXML(xmlDoc);
-    requestAnimationFrame(tieify);
   }
   console.log(event.target.files[0])
   reader.readAsText(event.target.files[0]);
@@ -1103,7 +1125,7 @@ function dragHandler(e) {
 
 function dropHandler(e){
   e.preventDefault();
-  const dropzone = e.target.closest('div'); 
+  const dropzone = e.target.closest('div');
   if (dropzone == null) return;
   const noteId = e.dataTransfer.getData('text');
   const draggedNote = document.getElementById(noteId)
@@ -1114,6 +1136,59 @@ function dropHandler(e){
   if (draggedNote.parentNode) {
     draggedNote.parentNode.removeChild(draggedNote);
   }
+}
+
+function detectPatternsFromSteps() {
+  console.log('Detecting patterns from note steps:', noteSteps);
+  const patterns = new Set();
+  const len = noteSteps.length;
+  for (let l = 1; l <= len / 2; l++) {
+    for (let i = 0; i <= len - 2 * l; i++) {
+      const a = noteSteps.slice(i, i + l).join('');
+      const b = noteSteps.slice(i + l, i + 2 * l).join('');
+      if (a === b) patterns.add(a);
+    }
+  }
+
+  detectedPatterns = {};
+  patterns.forEach(p => {
+    const seqLen = p.length;
+    const indexes = [];
+    for (let i = 0; i <= len - seqLen; i++) {
+      if (noteSteps.slice(i, i + seqLen).join('') === p) indexes.push(i);
+    }
+    if (indexes.length > 1) {
+      detectedPatterns[p] = { length: seqLen, positions: indexes };
+    }
+  });
+
+  console.log('Detected patterns:', detectedPatterns);
+
+  const select = document.getElementById('phraseSelect');
+  if (select) {
+    select.innerHTML = '<option value="">Select melody</option>';
+    Object.keys(detectedPatterns).forEach(p => {
+      const opt = document.createElement('option');
+      opt.value = p;
+      opt.textContent = p;
+      select.appendChild(opt);
+    });
+    console.log('Dropdown updated with patterns');
+  }
+}
+
+function highlightPhrase(p) {
+  noteElements.forEach(n => n.classList.remove('phrase-highlight'));
+  if (!p || !detectedPatterns[p]) return;
+  const info = detectedPatterns[p];
+  console.log('Highlighting phrase', p, info);
+  info.positions.forEach(pos => {
+    for (let i = 0; i < info.length; i++) {
+      const idx = pos + i;
+      const el = noteElements[idx];
+      if (el) el.classList.add('phrase-highlight');
+    }
+  });
 }
 
 function addStaffBlock(pitchSpace='e4',noteType='quarter') {
@@ -1192,6 +1267,19 @@ numericSettings.forEach(s => {
     tieify();
   });
 });
+
+const phraseSelect = document.getElementById('phraseSelect');
+if (phraseSelect) {
+  phraseSelect.addEventListener('change', e => highlightPhrase(e.target.value));
+}
+
+const runDetectBtn = document.getElementById('runDetect');
+if (runDetectBtn) {
+  runDetectBtn.addEventListener('click', () => {
+    console.log('Running phrase detection again');
+    detectPatternsFromSteps();
+  });
+}
 
 // Recalculate ties whenever layout changes
 window.addEventListener('resize', tieify);


### PR DESCRIPTION
## Summary
- add a `Run Detect Again` button next to the melody dropdown
- log note steps and detection results to the console
- highlight phrase logs when a pattern is selected

## Testing
- `npm test` *(fails: package.json missing)*【9effbc†L1-L14】
- `pytest` *(fails: command not found)*【162208†L1-L4】

[HTML preview](https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html)