### PR TITLE
Add touch swipe selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ https://htmlpreview.github.io/?https://raw.githubusercontent.com/<USER>/<REPO>/<
 Replace `<USER>`, `<REPO>` and `<BRANCH>` with the appropriate values to get a
 clickable link for testing a pull request.
 
+## Touch Support
+
+You can swipe across the staffs on mobile devices to select a phrase. When you lift your finger, all matching phrases in the score will be highlighted.
+

--- a/index.html
+++ b/index.html
@@ -1589,6 +1589,20 @@ sheetElement.addEventListener("mousedown", e => {
   e.preventDefault();
 });
 
+sheetElement.addEventListener("touchstart", e => {
+  const touch = e.touches[0];
+  const el = touch ? document.elementFromPoint(touch.clientX, touch.clientY) : e.target;
+  const block = el && el.closest(".staff");
+  if (!block) return;
+  staffList = Array.from(sheetElement.querySelectorAll(".staff"));
+  startIndex = staffList.indexOf(block);
+  if (startIndex === -1) return;
+  selecting = true;
+  clearSelection();
+  block.classList.add("selected");
+  e.preventDefault();
+});
+
 sheetElement.addEventListener("mousemove", e => {
   if (!selecting) return;
   const block = e.target.closest(".staff");
@@ -1600,6 +1614,22 @@ sheetElement.addEventListener("mousemove", e => {
   for (let i = start; i <= end; i++) {
     staffList[i].classList.add("selected");
   }
+});
+
+sheetElement.addEventListener("touchmove", e => {
+  if (!selecting) return;
+  const touch = e.touches[0];
+  const el = touch ? document.elementFromPoint(touch.clientX, touch.clientY) : e.target;
+  const block = el && el.closest(".staff");
+  if (!block) return;
+  const idx = staffList.indexOf(block);
+  if (idx === -1) return;
+  clearSelection();
+  const [start, end] = idx >= startIndex ? [startIndex, idx] : [idx, startIndex];
+  for (let i = start; i <= end; i++) {
+    staffList[i].classList.add("selected");
+  }
+  e.preventDefault();
 });
 
 function highlightExactFromSelection() {
@@ -1637,6 +1667,17 @@ document.addEventListener("mouseup", () => {
   if (selecting) {
     highlightExactFromSelection();
   }
+  selecting = false;
+});
+
+document.addEventListener("touchend", () => {
+  if (selecting) {
+    highlightExactFromSelection();
+  }
+  selecting = false;
+});
+
+document.addEventListener("touchcancel", () => {
   selecting = false;
 });
 


### PR DESCRIPTION
## Summary
- enable swipe selection and highlight matches on touch devices
- document mobile swipe support

## Testing
- `npm test` *(fails: Could not find package.json)*

[Preview HTML](https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html)
