### PR TITLE
Add drag-and-drop MusicXML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ You can swipe across the staffs on mobile devices to select a phrase. When you l
 
 Scrolling is disabled so swipe gestures work reliably. Use the new left and right arrows to move between pages. Each page spans exactly one screen height.
 
+## Importing Scores
+
+Drag a `.musicxml` or `.mxl` file onto the page to load a new score. MXL archives are unzipped automatically, and the first top-level XML file is used.
+
 ## Progressive Web App
 
 This site now includes a web manifest and service worker so it can be installed on mobile and desktop browsers. Add it to your home screen to use it like a native app.

--- a/index.html
+++ b/index.html
@@ -509,6 +509,7 @@ svg {
 } */
 
 </style>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
 </head>
 <!--
 .##.....##.########.##.....##.##......
@@ -659,6 +660,17 @@ document.addEventListener('touchstart', e => {
     e.preventDefault();
   }
 }, {passive: false});
+document.addEventListener('dragover', e => {
+  if (e.dataTransfer.types && Array.from(e.dataTransfer.types).includes('Files')) {
+    e.preventDefault();
+  }
+});
+document.addEventListener('drop', e => {
+  if (e.dataTransfer.files && e.dataTransfer.files.length) {
+    e.preventDefault();
+    loadFile(e.dataTransfer.files[0]);
+  }
+});
 
 // Global arrays for melody pattern detection
 let noteSteps = [];
@@ -1310,18 +1322,38 @@ function plotStaffBlock(existingStaffBlock, pitchSpace, noteType) {
 ###  #  ### # #  #  ##
 */
 
-function fileHandler(event) {
-  const reader = new FileReader();
-  reader.onload = () => {
-    const parser = new DOMParser();
-    const xmlDoc = parser
-      .parseFromString(reader.result,"text/xml");
-    displayScoreInfo(parseScoreInfo(xmlDoc));
-    populateStaffFromMusicXML(xmlDoc);
-    if (autoFeaturesEnabled) requestAnimationFrame(tieify);
+function parseAndPopulate(text) {
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(text, "text/xml");
+  displayScoreInfo(parseScoreInfo(xmlDoc));
+  populateStaffFromMusicXML(xmlDoc);
+  if (autoFeaturesEnabled) requestAnimationFrame(tieify);
+}
+
+function loadFile(file) {
+  if (!file) return;
+  if (file.name.toLowerCase().endsWith('.mxl')) {
+    JSZip.loadAsync(file).then(zip => {
+      const xmlName = Object.keys(zip.files).find(name => {
+        const lower = name.toLowerCase();
+        return lower.endsWith('.xml') &&
+               !lower.startsWith('meta-inf/') &&
+               !lower.includes('/');
+      });
+      if (!xmlName) throw new Error('No top-level XML file found in archive');
+      return zip.file(xmlName).async('string');
+    }).then(parseAndPopulate)
+      .catch(err => console.error('Error loading MXL file:', err));
+  } else {
+    const reader = new FileReader();
+    reader.onload = () => parseAndPopulate(reader.result);
+    reader.readAsText(file);
   }
-  console.log(event.target.files[0])
-  reader.readAsText(event.target.files[0]);
+}
+
+function fileHandler(event) {
+  const file = event.target.files[0];
+  loadFile(file);
 }
 
 function showMenu(e) {


### PR DESCRIPTION
## Summary
- allow dropping MusicXML and MXL files directly on the page
- unzip MXL archives to find a top-level XML
- document how to import scores via drag and drop

https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/work/index.html