### PR TITLE
Add melody copying and cross-file search

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,22 @@ svg {
     gap: 4px;
     background-color: var(--space-color);
   }
+  #searchTray {
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 200px;
+    background-color: var(--space-color);
+    border-right: 1px solid var(--line-color);
+    padding: 10px;
+    overflow-y: auto;
+    display: none;
+    z-index: 20;
+  }
+  #searchTray button {
+    margin-bottom: 10px;
+  }
   .controls button,
   .controls i,
   .controls select {
@@ -549,6 +565,7 @@ svg {
     <input type="range" id="darkOpacity" min="60" max="100" value="75">
   </label>
   <button id="toggleScoreInfo" class="tooltip" data-tooltip="Score Info"><i class="fa-solid fa-circle-info"></i></button>
+  <button id="searchMelody" class="tooltip" data-tooltip="Search Melody"><i class="fa-solid fa-magnifying-glass"></i></button>
   <button id="playStaff" class="tooltip" data-tooltip="Play"><i class="fa-solid fa-play"></i></button>
   <button id="toggleSound" class="tooltip" data-tooltip="Toggle Sound"><i class="fa-solid fa-volume-high"></i></button>
   <input id="stayTime" type="number" min="0.1" step="0.1" value="1" title="Whole Note Time (s)" style="width:3em;">
@@ -571,6 +588,11 @@ svg {
 
 </div>
 <div id="scoreInfo"></div>
+
+<div id="searchTray">
+  <button id="searchBack" class="tooltip" data-tooltip="Back"><i class="fa-solid fa-arrow-left"></i></button>
+  <div id="searchList"></div>
+</div>
 
 <div class="sheet">
   <div id="zoomContainer"></div>
@@ -697,6 +719,10 @@ let winningGroups = [];
 let autoFeaturesEnabled = false;
 
 let library = [];
+let openFiles = [];
+let currentFile = null;
+let previousContext = null;
+let afterLoadCallback = null;
 
 function loadLibrary() {
   library = JSON.parse(localStorage.getItem('xmlLibrary') || '[]');
@@ -732,6 +758,42 @@ function renderLibrary() {
     btn.addEventListener('click', () => parseAndPopulate(item.data, item.name));
     bar.appendChild(btn);
   });
+}
+
+function updateOpenFiles(name, data) {
+  currentFile = name;
+  const existing = openFiles.find(f => f.name === name);
+  const stepsCopy = noteSteps.slice();
+  if (existing) {
+    existing.data = data;
+    existing.steps = stepsCopy;
+  } else {
+    openFiles.push({ name, data, steps: stepsCopy });
+  }
+}
+
+function openFileByName(name, highlightRangeIndices) {
+  const item = library.find(f => f.name === name);
+  if (!item) return;
+  previousContext = previousContext || { file: currentFile, indices: highlightRangeIndices };
+  if (highlightRangeIndices) {
+    afterLoadCallback = () => {
+      highlightSelectedRange(highlightRangeIndices[0], highlightRangeIndices[1]);
+    };
+  } else {
+    afterLoadCallback = null;
+  }
+  parseAndPopulate(item.data, item.name);
+}
+
+function indexOfSubsequence(arr, sub) {
+  outer: for (let i = 0; i <= arr.length - sub.length; i++) {
+    for (let j = 0; j < sub.length; j++) {
+      if (arr[i + j] !== sub[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
 }
 
 
@@ -1318,6 +1380,10 @@ function populateStaffFromMusicXML(xmlDoc) {
         tieify();
         beamify();
       }
+      if (afterLoadCallback) {
+        afterLoadCallback();
+        afterLoadCallback = null;
+      }
   });
 }
 
@@ -1381,7 +1447,10 @@ function parseAndPopulate(text, name) {
   displayScoreInfo(parseScoreInfo(xmlDoc));
   populateStaffFromMusicXML(xmlDoc);
   if (autoFeaturesEnabled) requestAnimationFrame(tieify);
-  if (name) saveToLibrary(name, text);
+  if (name) {
+    saveToLibrary(name, text);
+    updateOpenFiles(name, text);
+  }
 }
 
 function loadFile(file) {
@@ -1553,6 +1622,18 @@ function drawPhraseBox(startIdx, endIdx, isWinner = false) {
   return box;
 }
 
+function highlightSelectedRange(startIdx, endIdx) {
+  noteElements.forEach(n => n.classList.remove('phrase-highlight'));
+  clearPhraseBoxes();
+  for (let i = startIdx; i <= endIdx; i++) {
+    const el = noteElements[i];
+    if (el) el.classList.add('phrase-highlight');
+  }
+  drawPhraseBox(startIdx, endIdx, true);
+  const el = noteElements[startIdx];
+  if (el) el.scrollIntoView({behavior:'smooth', block:'center'});
+}
+
 function detectDescendingPatterns() {
   const len = notePitches.length;
   const patterns = {};
@@ -1692,6 +1773,11 @@ const darkModeToggle = document.getElementById('toggleDarkMode');
 const toggleScoreInfoBtn = document.getElementById('toggleScoreInfo');
 const toggleExtraControlsBtn = document.getElementById('toggleExtraControls');
 
+const searchBtn = document.getElementById('searchMelody');
+const searchTray = document.getElementById('searchTray');
+const searchList = document.getElementById('searchList');
+const searchBackBtn = document.getElementById('searchBack');
+
 const autoFeatureToggle = document.getElementById('autoFeatures');
 if (autoFeatureToggle) {
   autoFeaturesEnabled = autoFeatureToggle.checked;
@@ -1810,6 +1896,41 @@ if (phraseBoxToggle) {
   phraseBoxToggle.addEventListener('change', () => {
     phraseBoxesEnabled = phraseBoxToggle.checked;
     if (!phraseBoxesEnabled) clearPhraseBoxes();
+  });
+}
+
+if (searchBtn) {
+  searchBtn.addEventListener('click', () => {
+    const indices = getSelectionIndices();
+    if (!indices) return;
+    const patternSteps = noteSteps.slice(indices[0], indices[1] + 1);
+    searchList.innerHTML = '';
+    openFiles.forEach(f => {
+      if (f.name === currentFile) return;
+      const idx = indexOfSubsequence(f.steps, patternSteps);
+      if (idx !== -1) {
+        const btn = document.createElement('button');
+        btn.textContent = f.name;
+        btn.addEventListener('click', () => {
+          searchTray.style.display = 'block';
+          openFileByName(f.name, [idx, idx + patternSteps.length - 1]);
+        });
+        searchList.appendChild(btn);
+      }
+    });
+    searchTray.style.display = 'block';
+    previousContext = { file: currentFile, indices };
+  });
+}
+
+if (searchBackBtn) {
+  searchBackBtn.addEventListener('click', () => {
+    searchTray.style.display = 'none';
+    if (previousContext) {
+      const ctx = previousContext;
+      previousContext = null;
+      openFileByName(ctx.file, ctx.indices);
+    }
   });
 }
 
@@ -2037,6 +2158,18 @@ function highlightExactFromSelection() {
   });
 }
 
+function getSelectionIndices() {
+  const selected = sheetElement.querySelectorAll('.staff.selected');
+  if (!selected.length) return null;
+  const firstNotes = selected[0].querySelectorAll('.note');
+  const lastNotes = selected[selected.length - 1].querySelectorAll('.note');
+  if (!firstNotes.length || !lastNotes.length) return null;
+  const startIdx = Math.min(...Array.from(firstNotes).map(n => parseInt(n.dataset.index)));
+  const endIdx = Math.max(...Array.from(lastNotes).map(n => parseInt(n.dataset.index)));
+  if (isNaN(startIdx) || isNaN(endIdx) || startIdx > endIdx) return null;
+  return [startIdx, endIdx];
+}
+
 document.addEventListener("mouseup", () => {
   if (selecting) {
     highlightExactFromSelection();
@@ -2065,6 +2198,17 @@ document.addEventListener("copy", e => {
     const text = Array.from(selected).map(el => el.dataset.letters || "").join("\n");
     e.clipboardData.setData("text/plain", text);
     e.preventDefault();
+  }
+});
+
+document.addEventListener('keydown', e => {
+  if ((e.key === 'c' || e.key === 'C') && (e.metaKey || e.ctrlKey)) {
+    const selected = sheetElement.querySelectorAll('.staff.selected');
+    if (selected.length) {
+      const text = Array.from(selected).map(el => el.dataset.letters || '').join('\n');
+      navigator.clipboard.writeText(text).catch(() => {});
+      e.preventDefault();
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- support copying selected note letters with Ctrl/Cmd+C
- add search tray for finding melodies across open files
- highlight found melodies and allow returning to previous position

[HTML preview link](https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html)
