### PR TITLE
Add MusicXML spec placeholder file

### DIFF
--- a/docs/MusicXML_Spec_Placeholder.md
+++ b/docs/MusicXML_Spec_Placeholder.md
@@ -1,0 +1,4 @@
+# MusicXML Specification Placeholder
+
+This file is reserved for the full MusicXML specification. You can paste the official documentation or any excerpts here for easy reference during development.
+


### PR DESCRIPTION
## Summary
- create a `docs` folder
- add `MusicXML_Spec_Placeholder.md` for pasting the MusicXML specification

## Testing
- `true`

https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html