### PR TITLE
Add preview URL script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ https://htmlpreview.github.io/?https://raw.githubusercontent.com/<USER>/<REPO>/<
 Replace `<USER>`, `<REPO>` and `<BRANCH>` with the appropriate values to get a
 clickable link for testing a pull request.
 
+You can also generate the exact URL for the current branch by running
+`./preview_link.py` from the repository root. Copy the printed link into your
+pull request description for a quick preview.
+
 ## Importing Scores
 
 Drag and drop a `.musicxml` or `.mxl` file onto the page or select it with the

--- a/preview_link.py
+++ b/preview_link.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import subprocess
+
+def get_current_branch():
+    result = subprocess.run(["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                            text=True, capture_output=True, check=True)
+    return result.stdout.strip()
+
+
+def main():
+    branch = get_current_branch()
+    url = (
+        "https://htmlpreview.github.io/?https://raw.githubusercontent.com/"
+        f"bryandebourbon/eMusicReader/{branch}/index.html"
+    )
+    print(url)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add a Python helper script that prints the HTML preview link for the current branch
- mention the helper in the README

## Testing
- `python3 preview_link.py`

HTML preview: https://htmlpreview.github.io/?https://raw.githubusercontent.com/bryandebourbon/eMusicReader/codex/work/index.html

------
https://chatgpt.com/codex/tasks/task_e_6841d4dfc31c832b8360e7cf4790d550